### PR TITLE
Persist specs between provide() calls

### DIFF
--- a/src/protestr/_provider.py
+++ b/src/protestr/_provider.py
@@ -7,10 +7,14 @@ def provide(**specs):
         def provided(*args, **kwds):
             from protestr import resolve
 
+            all_specs = {}
+
             for specs in provided.__specslist__:
+                all_specs |= specs | kwds
+
                 try:
                     resolved = {
-                        k: resolve(s) for k, s in (specs|kwds).items()
+                        k: resolve(s) for k, s in all_specs.items()
                     }
                     result = func(*args, **resolved)
                 finally:

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -21,7 +21,7 @@ def factorial(n):
 class TestExamples(unittest.TestCase):
     @provide(n=9, expected=362880)
     @provide(n=5, expected=120)
-    @provide(n=1, expected=1)
+    @provide(n=1)
     @provide(n=0, expected=1)
     def test_factorial_valid_number(self, n, expected):
         self.assertEqual(factorial(n), expected)
@@ -59,9 +59,7 @@ class TestExamples(unittest.TestCase):
             choices(ascii_uppercase, k=5),
             then="".join
         ),
-        expected="Password must contain a lowercase letter",
-        db=specs.testdb,
-        user=specs.user
+        expected="Password must contain a lowercase letter"
     )
     @provide(
         password=recipe(
@@ -69,15 +67,11 @@ class TestExamples(unittest.TestCase):
             choices(ascii_lowercase, k=5),
             then="".join
         ),
-        expected="Password must contain an uppercase letter",
-        db=specs.testdb,
-        user=specs.user
+        expected="Password must contain an uppercase letter"
     )
     @provide(
         password=choices(ascii_letters, k=8),
-        expected="Password must contain a number",
-        db=specs.testdb,
-        user=specs.user
+        expected="Password must contain a number"
     )
     @provide(
         password=choices(str, k=7),


### PR DESCRIPTION
For chained provide() calls, carry over specs to subsequent calls so that they can be omitted (reused) instead of redundantly specifying them every time. Test provide() to its limits. Restructure the readme.